### PR TITLE
build: add simulation target for jMAVSim

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Copyright (c) 2022 Jonathan Hahn
 # SPDX-License-Identifier: Apache-2.0
 
+include(cmake/simulate.cmake)
+
 add_subdirectory(drivers)
 add_subdirectory(lib)
 

--- a/cmake/simulate.cmake
+++ b/cmake/simulate.cmake
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+
+add_custom_target(simulate
+  COMMAND
+  echo "Simulation with jMAVSim was started."
+  DEPENDS 
+  ${logical_target_for_zephyr_elf}
+  jMAVSim_run
+  WORKING_DIRECTORY ${APPLICATION_BINARY_DIR}
+  USES_TERMINAL
+  )

--- a/docs/tutorials/simulation.rst
+++ b/docs/tutorials/simulation.rst
@@ -1,0 +1,12 @@
+.. _simulation:
+
+Simulation
+==========
+
+There is support to run _zephly_ in simulation on your host computer.
+To do that run
+
+.. code-block:: bash
+
+    west build --board=native_posix_64 app -t simulate
+

--- a/west.yml
+++ b/west.yml
@@ -9,5 +9,10 @@ manifest:
       remote: custom-zephyr
       revision: st-half-duplex-uart
       import: true
+    - name: jMAVSim
+      remote: custom-zephyr
+      revision: zephyr
+      path: modules/sim/jMAVSim
+      submodules: true
   self:
     path: zephly


### PR DESCRIPTION
The changes add the target `simulate` which can
be used to run jMAVSim.