### PR TITLE
drivers: control_output: generalize pwm output

### DIFF
--- a/boards/arm/openpilot_cc3d/openpilot_cc3d.dts
+++ b/boards/arm/openpilot_cc3d/openpilot_cc3d.dts
@@ -32,9 +32,10 @@
 		rc-uart = &usart1;
 	};
 
-	pwmout: pwmout0 {
+	pwmout: pwmout {
 		compatible = "zephly,pwmout";
-		label = "PWM_OUT0";
+		pwms = <&pwm1 4 0 0>, <&pwm1 3 0 0>, <&pwm1 2 0 0>, <&pwm2 1 0 0>;
+		label = "PWMOUT";
 		status = "okay";
 	};
 };

--- a/dts/bindings/zephly,pwmout.yaml
+++ b/dts/bindings/zephly,pwmout.yaml
@@ -4,3 +4,21 @@
 description: PWM Output
 
 compatible: "zephly,pwmout"
+
+include: base.yaml
+
+properties:
+    pwms:
+      required: false
+      type: phandle-array
+      description: PWM specifier driving the outputs.
+    
+    min-pulse:
+      required: false
+      type: int
+      description: Minimum pulse width (nanoseconds).
+
+    max-pulse:
+      required: false
+      type: int
+      description: Maximum pulse width (nanoseconds).


### PR DESCRIPTION
The pwm output was specific for openpilot board. With this commit
it becomes configurable via devicetree and should be usable for other
boards as well.